### PR TITLE
July 2023 Update: Postgresql 15

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,13 +22,13 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build image
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 FROM postgres:latest AS builder
 RUN mkdir /build
 WORKDIR /build
-RUN apt-get update && apt-get install -y build-essential postgresql-server-dev-all git libssl-dev zlib1g-dev libreadline-dev
+RUN apt-get update && apt-get install -y build-essential postgresql-server-dev-all git libssl-dev zlib1g-dev libreadline-dev liblz4-dev libzstd-dev
 RUN git clone https://github.com/segasai/q3c.git
 WORKDIR /build/q3c
 RUN make
-RUN /usr/lib/llvm-7/bin/llvm-lto -thinlto -thinlto-action=thinlink -o q3c.index.bc dump.bc q3c.bc q3c_poly.bc q3cube.bc
+RUN /usr/lib/llvm-14/bin/llvm-lto -thinlto -thinlto-action=thinlink -o q3c.index.bc dump.bc q3c.bc q3c_poly.bc q3cube.bc
 
 FROM postgres:latest
-LABEL org.opencontainers.image.source https://github.com/marxide/postgres-q3c
-RUN mkdir -p /usr/share/doc/postgresql-doc-13/extension /usr/lib/postgresql/13/lib/bitcode/q3c
-COPY --from=builder /build/q3c/q3c.so /usr/lib/postgresql/13/lib/q3c.so
-COPY --from=builder /build/q3c/q3c.control /usr/share/postgresql/13/extension/
-COPY --from=builder /build/q3c/scripts/*.sql /usr/share/postgresql/13/extension/
-COPY --from=builder /build/q3c/README.md /usr/share/doc/postgresql-doc-13/extension/
-COPY --from=builder /build/q3c/dump.bc /build/q3c/q3c.bc /build/q3c/q3c_poly.bc /build/q3c/q3cube.bc /usr/lib/postgresql/13/lib/bitcode/q3c/
-COPY --from=builder /build/q3c/q3c.index.bc /usr/lib/postgresql/13/lib/bitcode/
+LABEL org.opencontainers.image.source https://github.com/ajstewart/postgres-q3c
+RUN mkdir -p /usr/share/doc/postgresql-doc-15/extension /usr/lib/postgresql/15/lib/bitcode/q3c
+COPY --from=builder /build/q3c/q3c.so /usr/lib/postgresql/15/lib/q3c.so
+COPY --from=builder /build/q3c/q3c.control /usr/share/postgresql/15/extension/
+COPY --from=builder /build/q3c/scripts/*.sql /usr/share/postgresql/15/extension/
+COPY --from=builder /build/q3c/README.md /usr/share/doc/postgresql-doc-15/extension/
+COPY --from=builder /build/q3c/dump.bc /build/q3c/q3c.bc /build/q3c/q3c_poly.bc /build/q3c/q3cube.bc /usr/lib/postgresql/15/lib/bitcode/q3c/
+COPY --from=builder /build/q3c/q3c.index.bc /usr/lib/postgresql/15/lib/bitcode/
 COPY create_q3c_extension.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
This updates the image to use the latest versions of all involved.

- Postgresql is now v15.
- Q3C also required the installation of `liblz4-dev` and `libzstd-dev`.